### PR TITLE
fix: kick command, subscriberId field, and add KICK capability

### DIFF
--- a/src/constants/Capability.js
+++ b/src/constants/Capability.js
@@ -4,6 +4,7 @@ export const ADMIN = 1;
 export const MOD = 2;
 export const BANNED = 4;
 export const SILENCED = 8;
+export const KICK = 16;
 export const OWNER = 32;
 export const CO_OWNER = 64;
 
@@ -14,6 +15,7 @@ export default {
   MOD,
   BANNED,
   SILENCED,
+  KICK,
   OWNER,
   CO_OWNER
 };

--- a/src/helper/channel/Member.js
+++ b/src/helper/channel/Member.js
@@ -302,7 +302,7 @@ class Member extends Base {
       {
         body: {
           groupId: channelId,
-          id: userId,
+          subscriberId: userId,
           capabilities: target
         }
       }
@@ -361,11 +361,12 @@ class Member extends Base {
     }
 
     return this.client.websocket.emit(
-      Command.GROUP_MEMBER_DELETE,
+      Command.GROUP_MEMBER_UPDATE,
       {
         body: {
           groupId: channelId,
-          id: userId
+          subscriberId: userId,
+          capabilities: Capability.KICK
         }
       }
     );


### PR DESCRIPTION
Fixes #499

## Changes

### `src/constants/Capability.js`
- Added `KICK = 16` — the only missing server capability value. All others (REGULAR, ADMIN, MOD, BANNED, SILENCED, OWNER, CO_OWNER) were already present.

### `src/helper/channel/Member.js` — `kick()`
- **Wrong command**: was emitting `GROUP_MEMBER_DELETE` (`'group member delete'`) which the WOLF server interprets as a self-leave, removing the bot from the channel and ignoring any target user ID
- **Wrong field name**: `id` → `subscriberId`
- **Missing capability**: added `capabilities: Capability.KICK`

The official app sends:
```js
command: 'group member update'
body: { subscriberId, groupId, capabilities: 16 }
```

### `src/helper/channel/Member.js` — `updateCapability()`
- **Wrong field name**: `id` → `subscriberId` — the WOLF server expects `subscriberId` in all `'group member update'` requests; this affected every capability transition (admin, mod, ban, silence, co-owner)

## Before / After

| | Before | After |
|---|---|---|
| `kick(groupId, userId)` | Bot leaves the channel | Target user is kicked ✅ |
| `admin/mod/ban/silence/coowner` | Sent with wrong field `id` | Sent with correct field `subscriberId` ✅ |