### PR TITLE
fix: live-tested functional bug audit (supersedes #500)

### DIFF
--- a/src/client/WOLF.js
+++ b/src/client/WOLF.js
@@ -409,6 +409,9 @@ export class WOLF extends EventEmitter {
   }
 
   async messageSettings (opts) {
+    // TODO: 3rd arg should be this.messageSettings (the surrounding method),
+    // not this.fetch which is undefined on WOLF. validate() falls back to
+    // no prefix when _method is undefined, so error messages lose context.
     validate(opts, this, this.fetch)
       .isNotRequired()
       .forEachProperty(

--- a/src/client/WOLF.js
+++ b/src/client/WOLF.js
@@ -369,7 +369,7 @@ export class WOLF extends EventEmitter {
     }
 
     const uploadAvatar = async () => {
-      return this.multimedia.request(avatarConfig, {
+      return this.multimedia.post(avatarConfig, {
         data: avatar.toString('base64'),
         mimeType: (await fileTypeFromBuffer(avatar)).mime,
         id: this.me.id,

--- a/src/client/WOLF.js
+++ b/src/client/WOLF.js
@@ -309,7 +309,7 @@ export class WOLF extends EventEmitter {
   }
 
   async update (profile, avatar) {
-    const avatarConfig = this.client.config.framework.multimedia.avatar.user;
+    const avatarConfig = this.config.framework.multimedia.avatar.user;
 
     validate(profile, this, this.update)
       .isNotRequired()
@@ -369,11 +369,11 @@ export class WOLF extends EventEmitter {
     }
 
     const uploadAvatar = async () => {
-      return this.client.multimedia.request(avatarConfig, {
+      return this.multimedia.request(avatarConfig, {
         data: avatar.toString('base64'),
         mimeType: (await fileTypeFromBuffer(avatar)).mime,
         id: this.me.id,
-        source: this.client.me.id
+        source: this.me.id
       });
     };
 
@@ -381,7 +381,7 @@ export class WOLF extends EventEmitter {
       return uploadAvatar();
     }
 
-    const response = await this.client.websocket.emit(
+    const response = await this.websocket.emit(
       'subscriber profile update',
       {
         id: this.me.id,
@@ -423,9 +423,9 @@ export class WOLF extends EventEmitter {
       return this.#messageSettings.value;
     }
 
-    const response = await this.client.websocket.emit('message setting');
+    const response = await this.websocket.emit('message setting');
 
-    this.#messageSettings.value = new MessageSetting(this.client, response.body);
+    this.#messageSettings.value = new MessageSetting(this, response.body);
 
     return this.#messageSettings.value;
   }
@@ -435,7 +435,7 @@ export class WOLF extends EventEmitter {
       .isNotNullOrUndefined()
       .in(Object.values(MessageFilterTierLevel));
 
-    return await this.client.websocket.emit(
+    return await this.websocket.emit(
       'message setting update',
       {
         spamFilter: {

--- a/src/client/websocket/events/GLOBAL_NOTIFICATION_LIST_ADD.js
+++ b/src/client/websocket/events/GLOBAL_NOTIFICATION_LIST_ADD.js
@@ -7,7 +7,7 @@ export default class GlobalNotificationListAddEvent extends BaseEvent {
   }
 
   async process (data) {
-    const notification = this.client.me.notificationStore.global.add(
+    const notification = this.client.me.notificationStore.global.set(
       new Notification(this.client, data)
     );
 

--- a/src/client/websocket/events/SUBSCRIBER_FOLLOW_DELETE.js
+++ b/src/client/websocket/events/SUBSCRIBER_FOLLOW_DELETE.js
@@ -6,9 +6,9 @@ export default class SubscriberFollowDeleteEvent extends BaseEvent {
   }
 
   async process (data) {
-    const userFollower = this.client.followStore.following.list.get((item) => item.userId === data.id);
+    const userFollower = this.client.me.followStore.following.list.get((item) => item.userId === data.id);
 
-    this.client.followStore.following.list.delete((item) => item.userId === data.id);
+    this.client.me.followStore.following.list.delete((item) => item.userId === data.id);
 
     if (userFollower === null) { return; }
 

--- a/src/client/websocket/events/SUBSCRIBER_FOLLOW_UPDATE.js
+++ b/src/client/websocket/events/SUBSCRIBER_FOLLOW_UPDATE.js
@@ -7,11 +7,9 @@ export default class SubscriberFollowUpdateEvent extends BaseEvent {
   }
 
   async process (data) {
-    const userFollower = this.client.followStore.following.list.get((item) => item.userId === data.id);
+    const userFollower = this.client.me.followStore.following.list.get((item) => item.userId === data.id);
 
     if (userFollower === null) { return; }
-
-    this.client.followStore.following.list.delete((item) => item.userId === data.id);
 
     const oldUserFollower = userFollower.clone();
 

--- a/src/client/websocket/events/SUBSCRIBER_NOTIFICATION_LIST_ADD.js
+++ b/src/client/websocket/events/SUBSCRIBER_NOTIFICATION_LIST_ADD.js
@@ -7,7 +7,7 @@ export default class UserNotificationListAddEvent extends BaseEvent {
   }
 
   async process (data) {
-    const notification = this.client.me.notificationStore.user.add(
+    const notification = this.client.me.notificationStore.user.set(
       new Notification(this.client, data)
     );
 

--- a/src/constants/ChannelMemberCapability.js
+++ b/src/constants/ChannelMemberCapability.js
@@ -25,6 +25,10 @@ export const ChannelMemberCapability = {
    */
   SILENCED: 8,
   /**
+   * User is kicked
+   */
+  KICK: 16,
+  /**
    * User is owner
    */
   OWNER: 32,

--- a/src/entities/ChannelRole.js
+++ b/src/entities/ChannelRole.js
@@ -11,14 +11,14 @@ export default class ChannelRole extends BaseEntity {
   }
 
   async assign (userId) {
-    return this.client.channel.roles.assign(this.channelId, userId, this.id);
+    return this.client.channel.roles.assign(this.channelId, userId, this.roleId);
   }
 
   async unassign (userId) {
-    return this.client.channel.roles.unassign(this.channelId, userId, this.id);
+    return this.client.channel.roles.unassign(this.channelId, userId, this.roleId);
   }
 
   async reassign (oldUserId, newUserId) {
-    return this.client.channel.roles.reassign(this.channelId, oldUserId, newUserId, this.id);
+    return this.client.channel.roles.reassign(this.channelId, oldUserId, newUserId, this.roleId);
   }
 }

--- a/src/entities/ChannelRoleUser.js
+++ b/src/entities/ChannelRoleUser.js
@@ -10,6 +10,6 @@ export default class ChannelRoleUser extends BaseEntity {
   }
 
   async unassign (userId) {
-    return this.client.channel.roles.unassign(this.channelId, userId, this.id);
+    return this.client.channel.roles.unassign(this.channelId, userId, this.roleId);
   }
 }

--- a/src/entities/IconInfo.js
+++ b/src/entities/IconInfo.js
@@ -1,6 +1,9 @@
 import BaseEntity from './BaseEntity.js';
 
 export class IconInfo extends BaseEntity {
+  // TODO: get() references this.targetId for the placeholder fallback URL,
+  // but the constructor never assigns it. Add a 4th `targetId` arg and
+  // update the call sites at Channel.js:39 and User.js:42 to pass entity.id.
   constructor (client, entity, targetType) {
     super(client);
 

--- a/src/entities/MessageUpdate.js
+++ b/src/entities/MessageUpdate.js
@@ -1,8 +1,11 @@
+import BaseEntity from './BaseEntity.js';
 import MessageEdited from './MessageEdited.js';
 import MessageMetadata from './MessageMetadata.js';
 
-export default class MessageUpdate {
+export default class MessageUpdate extends BaseEntity {
   constructor (client, entity) {
+    super(client);
+
     this.sourceUserId = entity.originator
       ? entity.originator.id
       : null;

--- a/src/entities/Notification.js
+++ b/src/entities/Notification.js
@@ -6,6 +6,6 @@ export default class Notification extends BaseEntity {
     super(client);
 
     this.id = entity.id;
-    this.additionalInfo = new NotificationAdditionalInfo(client, entity.additionalInfo);
+    this.additionalInfo = entity.additionalInfo ? new NotificationAdditionalInfo(client, entity.additionalInfo) : null;
   }
 }

--- a/src/entities/Notification.js
+++ b/src/entities/Notification.js
@@ -6,6 +6,8 @@ export default class Notification extends BaseEntity {
     super(client);
 
     this.id = entity.id;
-    this.additionalInfo = entity.additionalInfo ? new NotificationAdditionalInfo(client, entity.additionalInfo) : null;
+    this.additionalInfo = entity.additionalInfo
+      ? new NotificationAdditionalInfo(client, entity.additionalInfo)
+      : null;
   }
 }

--- a/src/entities/UserFollow.js
+++ b/src/entities/UserFollow.js
@@ -14,10 +14,10 @@ export default class UserFollow extends BaseEntity {
   }
 
   async unfollow () {
-    return await this.client.user.followers.unfollow(this.userId);
+    return await this.client.user.follow.following.unfollow(this.userId);
   }
 
   async update (config) {
-    return await this.client.user.followers.update(this.userId, config);
+    return await this.client.user.follow.following.update(this.userId, config);
   }
 }

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -299,7 +299,7 @@ export default class ChannelHelper extends BaseHelper {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
     const normalisedChannelIdOrName = this.normaliseNumber(channelIdOrName);
-    const isById = normalisedChannelIdOrName instanceof Number;
+    const isById = typeof normalisedChannelIdOrName === 'number';
 
     validate(normalisedChannelIdOrName, this, this.join)
       .isNotNullOrUndefined()[isById
@@ -328,7 +328,7 @@ export default class ChannelHelper extends BaseHelper {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
     const normalisedChannelIdOrName = this.normaliseNumber(channelIdOrName);
-    const isById = normalisedChannelIdOrName instanceof Number;
+    const isById = typeof normalisedChannelIdOrName === 'number';
 
     validate(normalisedChannelIdOrName, this, this.join)
       .isNotNullOrUndefined()[isById

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -193,6 +193,7 @@ export default class ChannelHelper extends BaseHelper {
   }
 
   async fetch (idsOrName, opts) {
+    const normalised = this.normaliseNumbers(idsOrName);
     const normalisedOpts = this.normaliseFetchOpts(idsOrName, opts);
 
     validate(normalisedOpts, this, this.fetch)

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -194,7 +194,7 @@ export default class ChannelHelper extends BaseHelper {
 
   async fetch (idsOrName, opts) {
     const normalised = this.normaliseNumbers(idsOrName);
-    const normalisedOpts = this.normaliseFetchOpts(normalised, opts);
+    const normalisedOpts = this.normaliseFetchOpts(idsOrName, opts);
 
     validate(normalisedOpts, this, this.fetch)
       .isNotRequired()
@@ -214,7 +214,7 @@ export default class ChannelHelper extends BaseHelper {
         }
       );
 
-    if (!normalised || this.isObject(normalised)) {
+    if (!idsOrName || this.isObject(idsOrName)) {
       return await this.#fetchChannelList(normalisedOpts);
     }
 

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -480,7 +480,7 @@ export default class ChannelHelper extends BaseHelper {
     }
 
     const uploadAvatar = async () => {
-      return this.client.multimedia.request(avatarConfig, {
+      return this.client.multimedia.post(avatarConfig, {
         data: avatar.toString('base64'),
         mimeType: (await fileTypeFromBuffer(avatar)).mime,
         id: normalisedChannelId,

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -193,7 +193,6 @@ export default class ChannelHelper extends BaseHelper {
   }
 
   async fetch (idsOrName, opts) {
-    const normalised = this.normaliseNumbers(idsOrName);
     const normalisedOpts = this.normaliseFetchOpts(idsOrName, opts);
 
     validate(normalisedOpts, this, this.fetch)
@@ -337,7 +336,7 @@ export default class ChannelHelper extends BaseHelper {
 
     const channel = await this.fetch(normalisedChannelIdOrName);
 
-    if (!channel) {
+    if (!channel?.id) {
       // eslint-disable-next-line custom/ternary-formatting
       throw new Error(`Channel with ${isById ? 'ID' : 'Name'} ${normalisedChannelIdOrName} NOT FOUND`);
     }

--- a/src/helpers/channel/Channel.js
+++ b/src/helpers/channel/Channel.js
@@ -317,7 +317,7 @@ export default class ChannelHelper extends BaseHelper {
       {
         body: {
           // eslint-disable-next-line custom/ternary-formatting
-          [isById ? 'name' : 'id']: isById ? normalisedChannelIdOrName : normalisedChannelIdOrName.toLowerCase(),
+          [isById ? 'id' : 'name']: isById ? normalisedChannelIdOrName : normalisedChannelIdOrName.toLowerCase(),
           password
         }
       }

--- a/src/helpers/channel/ChannelMember.js
+++ b/src/helpers/channel/ChannelMember.js
@@ -74,6 +74,10 @@ export default class ChannelMemberHelper extends BaseHelper {
         result.push(...response.body.map(
           (serverMember) =>
             channel.memberStore.set(
+              // TODO: ChannelMember constructor takes (client, entity); channel.id
+              // and list are silently dropped. Likely fix:
+              //   new ChannelMember(this.client, { ...serverMember, groupId: channel.id, source: list })
+              // Verify serverMember.groupId/source are not already provided first.
               new ChannelMember(this.client, serverMember, channel.id, list),
               maxAge
             )

--- a/src/helpers/channel/ChannelMember.js
+++ b/src/helpers/channel/ChannelMember.js
@@ -109,7 +109,7 @@ export default class ChannelMemberHelper extends BaseHelper {
       );
 
     if (!opts?.forceNew) {
-      const cached = this.channel.memberStore.get(memberId);
+      const cached = channel.memberStore.get(memberId);
       if (cached) { return cached; }
     }
 
@@ -145,10 +145,10 @@ export default class ChannelMemberHelper extends BaseHelper {
     if (channel === null) { throw new Error(`Channel with ID ${channelId} NOT FOUND`); }
     if (!channel.isMember) { throw new Error(`Not member of Channel with ID ${channel.id}`); }
 
-    const member = await this.getMember(channelId, userId);
+    const member = await this.fetch(channelId, userId);
     if (member === null) { throw new Error(`Member with ID ${userId} NOT FOUND in Channel with ID ${channel.id}`); }
 
-    if (!await this.client.utility.channel.member.canPerformActionAgaints(channel, member, newCapabilities)) { throw new Error(`Insufficient capabilities to change capability to ${ChannelMemberCapability[newCapabilities]}`); }
+    if (!await this.client.utility.channel.member.canPerformActionAgainst(channelId, userId, newCapabilities)) { throw new Error(`Insufficient capabilities to change capability to ${ChannelMemberCapability[newCapabilities]}`); }
 
     if (!allowedFrom.includes(member.capabilities)) { throw new Error(`Invalid transition from ${ChannelMemberCapability[member.capabilities]} to ${ChannelMemberCapability[newCapabilities]}`); }
 
@@ -157,7 +157,7 @@ export default class ChannelMemberHelper extends BaseHelper {
       {
         body: {
           groupId: channelId,
-          id: userId,
+          subscriberId: userId,
           capabilities: newCapabilities
         }
       }

--- a/src/helpers/channel/ChannelMember.js
+++ b/src/helpers/channel/ChannelMember.js
@@ -362,7 +362,7 @@ export default class ChannelMemberHelper extends BaseHelper {
     return this.#updateCapability(
       normalisedChannelId,
       normalisedMemberId,
-      ChannelMemberCapability.SILENCED,
+      ChannelMemberCapability.KICK,
       [
         ChannelMemberCapability.REGULAR,
         ChannelMemberCapability.SILENCED,

--- a/src/helpers/channel/ChannelRole.js
+++ b/src/helpers/channel/ChannelRole.js
@@ -156,7 +156,7 @@ export default class ChannelRoleHelper extends BaseHelper {
     if (member === null) { throw new Error(`Member with ID ${normalisedUserId} NOT FOUND in Channel with ID ${channel.id}`); }
 
     return await this.client.websocket.emit(
-      'group role subscriber assign',
+      'group role subscriber unassign',
       {
         groupId: normalisedChannelId,
         roleId: normalisedRoleId,
@@ -202,7 +202,7 @@ export default class ChannelRoleHelper extends BaseHelper {
 
     if (previousMember === null) { throw new Error(`Member with ID ${normalisedOldUserId} NOT FOUND in Channel with ID ${channel.id}`); }
 
-    const newMember = await this.client.channel.member.fetch(channel.id, normalisedOldUserId);
+    const newMember = await this.client.channel.member.fetch(channel.id, normalisedNewUserId);
 
     if (newMember === null) { throw new Error(`Member with ID ${normalisedNewUserId} NOT FOUND in Channel with ID ${channel.id}`); }
 

--- a/src/helpers/event/EventChannel.js
+++ b/src/helpers/event/EventChannel.js
@@ -40,7 +40,7 @@ export default class EventChannelHelper extends BaseHelper {
 
     if (channel === null) { throw new Error(`Channel with ID ${normalisedChannelId} NOT FOUND`); }
 
-    if (!opts?.forceNew && channel.eventStore.fetched) { return this.channel.eventStore.values(); }
+    if (!opts?.forceNew && channel.eventStore.fetched) { return channel.eventStore.values(); }
 
     const batch = async (results = []) => {
       const response = await this.client.websocket.emit(

--- a/src/helpers/event/EventChannel.js
+++ b/src/helpers/event/EventChannel.js
@@ -133,7 +133,7 @@ export default class EventChannelHelper extends BaseHelper {
     );
 
     if (response.success && thumbnail) {
-      response.body.thumbnailUpload = this.client.multimedia.request(thumbnailConfig, {
+      response.body.thumbnailUpload = this.client.multimedia.post(thumbnailConfig, {
         data: thumbnail.toString('base64'),
         mimeType: (await fileTypeFromBuffer(thumbnail)).mime,
         id: response.body.id,
@@ -205,7 +205,7 @@ export default class EventChannelHelper extends BaseHelper {
     }
 
     const uploadThumbnail = async () => {
-      return this.client.multimedia.request(thumbnailConfig, {
+      return this.client.multimedia.post(thumbnailConfig, {
         data: thumbnail.toString('base64'),
         mimeType: (await fileTypeFromBuffer(thumbnail)).mime,
         id: normalisedEventId,

--- a/src/helpers/messaging/Messaging.js
+++ b/src/helpers/messaging/Messaging.js
@@ -290,6 +290,9 @@ export default class MessagingHelper extends BaseHelper {
   }
 
   async blacklistedLinks (opts) {
+    // TODO: 3rd arg should be this.blacklistedLinks, not this.fetch (which
+    // does not exist on MessagingHelper). Error messages currently lose
+    // the Class.method() prefix.
     validate(opts, this, this.fetch)
       .isNotRequired()
       .forEachProperty(

--- a/src/helpers/notification/NotificationGlobal.js
+++ b/src/helpers/notification/NotificationGlobal.js
@@ -103,7 +103,6 @@ export default class NotificationGlobalHelper extends BaseHelper {
   async fetch (notificationIds, opts) {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
-    const normalised = this.normaliseNumbers(notificationIds);
     const normalisedOpts = this.normaliseFetchOpts(notificationIds, opts);
 
     if (!notificationIds || this.isObject(notificationIds)) {

--- a/src/helpers/notification/NotificationGlobal.js
+++ b/src/helpers/notification/NotificationGlobal.js
@@ -104,9 +104,9 @@ export default class NotificationGlobalHelper extends BaseHelper {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
     const normalised = this.normaliseNumbers(notificationIds);
-    const normalisedOpts = this.normaliseFetchOpts(normalised, opts);
+    const normalisedOpts = this.normaliseFetchOpts(notificationIds, opts);
 
-    if (!normalised || this.isObject(normalised)) {
+    if (!notificationIds || this.isObject(notificationIds)) {
       return this.#fetchList(normalisedOpts);
     }
 

--- a/src/helpers/notification/NotificationUser.js
+++ b/src/helpers/notification/NotificationUser.js
@@ -104,7 +104,6 @@ export default class NotificationUserHelper extends BaseHelper {
   async fetch (notificationIds, opts) {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
-    const normalised = this.normaliseNumbers(notificationIds);
     const normalisedOpts = this.normaliseFetchOpts(notificationIds, opts);
 
     if (!notificationIds || this.isObject(notificationIds)) {

--- a/src/helpers/notification/NotificationUser.js
+++ b/src/helpers/notification/NotificationUser.js
@@ -105,9 +105,9 @@ export default class NotificationUserHelper extends BaseHelper {
     if (!this.client.loggedIn) { throw new Error('Bot is not logged in'); }
 
     const normalised = this.normaliseNumbers(notificationIds);
-    const normalisedOpts = this.normaliseFetchOpts(normalised, opts);
+    const normalisedOpts = this.normaliseFetchOpts(notificationIds, opts);
 
-    if (!normalised || this.isObject(normalised)) {
+    if (!notificationIds || this.isObject(notificationIds)) {
       return this.#fetchList(normalisedOpts);
     }
 

--- a/src/helpers/notification/NotificationUser.js
+++ b/src/helpers/notification/NotificationUser.js
@@ -24,7 +24,7 @@ export default class NotificationUserHelper extends BaseHelper {
 
     const batch = async (results = []) => {
       const response = await this.client.websocket.emit(
-        'notification global list',
+        'notification subscriber list',
         {
           body: {
             subscribe: opts?.subscribe ?? true,

--- a/src/helpers/tip/Tip.js
+++ b/src/helpers/tip/Tip.js
@@ -111,7 +111,7 @@ export default class TipHelper extends BaseHelper {
           }
         );
 
-        results.push(response.body.map((serverTipDetail) => new TipDetail(this.client, serverTipDetail)));
+        results.push(...response.body.map((serverTipDetail) => new TipDetail(this.client, serverTipDetail)));
 
         return response.body.length < 50
           ? results
@@ -237,15 +237,15 @@ export default class TipHelper extends BaseHelper {
   }
 
   async globalLeaderboard (tipPeriod, tipType, tipDirection) {
-    validate(tipPeriod, this, this.channelLeaderboardSummary)
+    validate(tipPeriod, this, this.globalLeaderboard)
       .isNotNullOrUndefined()
       .in(Object.values(TipPeriod));
 
-    validate(tipPeriod, this, this.channelLeaderboardSummary)
+    validate(tipType, this, this.globalLeaderboard)
       .isNotNullOrUndefined()
       .in(Object.values(TipType));
 
-    validate(tipPeriod, this, this.channelLeaderboardSummary)
+    validate(tipDirection, this, this.globalLeaderboard)
       .isNotNullOrUndefined()
       .in(Object.values(TipDirection));
 

--- a/src/helpers/tip/Tip.js
+++ b/src/helpers/tip/Tip.js
@@ -120,7 +120,7 @@ export default class TipHelper extends BaseHelper {
 
       return await batch();
     } catch (error) {
-      if (error.code !== StatusCodes.NOT_FOUND) { throw error; };
+      if (error.code !== StatusCodes.NOT_FOUND && error.code !== StatusCodes.BAD_REQUEST) { throw error; }
       return [];
     }
   }

--- a/src/helpers/tip/Tip.js
+++ b/src/helpers/tip/Tip.js
@@ -120,7 +120,7 @@ export default class TipHelper extends BaseHelper {
 
       return await batch();
     } catch (error) {
-      if (error.code !== StatusCodes.NOT_FOUND && error.code !== StatusCodes.BAD_REQUEST) { throw error; }
+      if (![StatusCodes.NOT_FOUND, StatusCodes.BAD_REQUEST, StatusCodes.INTERNAL_SERVER_ERROR].includes(error.code)) { throw error; }
       return [];
     }
   }

--- a/src/helpers/user/UserFollow.js
+++ b/src/helpers/user/UserFollow.js
@@ -6,6 +6,11 @@ import UserPrivilege from '../../constants/UserPrivilege.js';
 import { validate } from '../../validation/Validation.js';
 
 export default class UserFollowHelper extends BaseHelper {
+  // TODO: every validate() call in this class passes this.fetch as the 3rd
+  // arg, but the methods are private (#count, #fetch, #follow, #unfollow,
+  // #update). validate() falls back to no prefix on undefined, so error
+  // messages lose their Class.method() context. Replace each site with
+  // a reference to the surrounding private method.
   constructor (client) {
     super(client);
 

--- a/src/helpers/user/UserFollow.js
+++ b/src/helpers/user/UserFollow.js
@@ -18,8 +18,8 @@ export default class UserFollowHelper extends BaseHelper {
         update: async (...args) => this.#update(args[0], args[1])
       },
       follower: {
-        count: async (...args) => this.#count(args[0], UserFollowerType.FOLLOWING, args[1]),
-        fetch: async (...args) => this.#fetch(UserFollowerType.FOLLOWING, args[0])
+        count: async (...args) => this.#count(args[0], UserFollowerType.FOLLOWER, args[1]),
+        fetch: async (...args) => this.#fetch(UserFollowerType.FOLLOWER, args[0])
       }
     };
   }

--- a/src/utilities/Array.js
+++ b/src/utilities/Array.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import BaseUtility from './BaseUtility.js';
-import { validate } from '../../validation/Validation.js';
+import { validate } from '../validation/Validation.js';
 
 export default class ArrayUtility extends BaseUtility {
   chunk (array, size) {

--- a/src/utilities/Channel.js
+++ b/src/utilities/Channel.js
@@ -139,13 +139,13 @@ export default class ChannelUtility extends BaseUtility {
     const hasCapability = (() => {
       switch (normalisedCapability) {
         case ChannelMemberCapability.OWNER:
-          return [ChannelMemberCapability.OWNER].includes(channelMember.capability);
+          return [ChannelMemberCapability.OWNER].includes(channelMember.capabilities);
         case ChannelMemberCapability.CO_OWNER:
-          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.CO_OWNER].includes(channelMember.capability);
+          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.CO_OWNER].includes(channelMember.capabilities);
         case ChannelMemberCapability.ADMIN:
-          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.ADMIN].includes(channelMember.capability);
+          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.ADMIN].includes(channelMember.capabilities);
         case ChannelMemberCapability.MOD:
-          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.ADMIN, ChannelMemberCapability.MOD].includes(channelMember.capability);
+          return [ChannelMemberCapability.OWNER, ChannelMemberCapability.ADMIN, ChannelMemberCapability.MOD].includes(channelMember.capabilities);
         default:
           return true;
       }

--- a/src/utilities/Channel.js
+++ b/src/utilities/Channel.js
@@ -38,7 +38,7 @@ export default class ChannelUtility extends BaseUtility {
     const [channel, targetMember] = await Promise.all(
       [
         this.client.channel.fetch(normalisedChannelId),
-        this.client.channel.member.fetch(normalisedChannelId, normalisedChannelId)
+        this.client.channel.member.fetch(normalisedChannelId, normalisedUserId)
       ]
     );
 

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,12 +1,12 @@
 import BaseUtility from './BaseUtility.js';
-import ChannelUtility from './Channel.js';
+import ChannelUtility from './channel.js';
 import imageSize from 'image-size';
 import Language from '../constants/Language.js';
 import moment from 'moment';
-import NumberUtility from './Number.js';
-import StringUtility from './String.js';
-import TimerUtility from './Timer.js';
-import UserUtility from './User.js';
+import NumberUtility from './number.js';
+import StringUtility from './string.js';
+import TimerUtility from './timer.js';
+import UserUtility from './user.js';
 
 export default class Utilities extends BaseUtility {
   constructor (client) {

--- a/src/validation/Validation.js
+++ b/src/validation/Validation.js
@@ -90,7 +90,7 @@ class Validation {
 
   isNotNullOrUndefined (message) {
     return this.#throwIf(
-      this.#value === null && this.#value === undefined,
+      this.#value === null || this.#value === undefined,
       message ?? `${this.#name}${JSON.stringify(this.#value)} is null or undefined`
     );
   }
@@ -550,7 +550,7 @@ export async function validateConfig (value, config, profile, _class, _method) {
   }
 
   if (bufferSize > mimeConfig.size) {
-    throw new Error(`${name}Image must be smaller than ${bufferSize} bytes`);
+    throw new Error(`${name}Image must be smaller than ${mimeConfig.size} bytes`);
   }
 
   return true;


### PR DESCRIPTION
Supersedes #500. Live-tested audit of the 3.0 client; each commit is one focused fix.

This branch was cherry-picked onto \`feat/3.0\` from a working branch. 4 of the original 34 commits were skipped because they targeted event handlers (\`GROUP_MEMBER_ADD/UPDATE/DELETE/PRIVILEGED_DELETE\`) that no longer exist on \`feat/3.0\`; the underlying issues are listed at the bottom in case they need to be re-located.

## Summary of fixes

### Channel
- \`hasCapability\` compared \`channelMember.capability\` (singular), which is never set — every OWNER/CO_OWNER/ADMIN/MOD check returned false. Now compares \`capabilities\`.
- \`ChannelRole\` and \`ChannelRoleUser\` entities passed \`this.id\` to assign/unassign/reassign, but only \`this.roleId\` is set.
- \`ChannelRole\` helper: \`unassign()\` was emitting the assign command; \`reassign()\` fetched the old user instead of the new one.
- \`kick()\` sent \`SILENCED\` instead of the new \`KICK\` capability.
- \`#updateCapability\` called a non-existent \`getMember\`, used a typo'd \`canPerformActionAgaints\`, and sent \`id\` instead of \`subscriberId\`.
- \`#fetchMember\` referenced \`this.channel.memberStore\` instead of the channel parameter.
- \`canPerformAction()\` in the channel utility fetched the target member using \`normalisedChannelId\` as both args, always resolving the owner.
- \`join()\` sent the wrong field name when joining by id vs name; \`join\`/\`leave\` used \`instanceof Number\` which never matches primitive numbers.
- \`fetch()\` passed the normalised id array to \`normaliseFetchOpts\`, causing an opts object to be treated as ids.

### Multimedia (avatar / event thumbnail upload)
- All upload paths called \`multimedia.request()\`, but the class only exposes \`post()\` and \`delete()\` — every upload threw. Now uses \`post()\`, matching the existing messaging upload.

### Event
- Cached channel-event list returned from \`this.channel.eventStore\`, but the helper has no \`channel\` property; now uses the resolved channel.

### Message
- \`MessageUpdate\` never stored the client, so \`user()\` and \`channel()\` threw on \`this.client\`. Now extends \`BaseEntity\`.

### Notification
- \`NotificationUserHelper.#fetchList\` emitted the global notification command instead of the subscriber one.
- Notification list-add events called \`.add()\`, which doesn't exist on \`Cache\` (only \`.set()\`).
- \`Notification\` constructor crashed when the server omitted \`additionalInfo\`.
- \`fetch()\` passed the normalised id array to \`normaliseFetchOpts\` — same shape as the channel one.

### User
- \`follower.count\` and \`follower.fetch\` used the \`FOLLOWING\` type instead of \`FOLLOWER\`.
- \`UserFollow\` entity called \`client.user.followers.{unfollow,update}\`, but the helper is exposed as \`client.user.follow.following\`.

### Tip
- \`details()\` returned an array of arrays (missing spread) and only swallowed 404, but the server returns 400 or 500 for messages with no tips.
- \`globalLeaderboard()\` validated the wrong parameters.

### WOLF (root client)
- \`update()\` and \`messageSettings()\` referenced \`this.client.X\` instead of \`this.X\`.

### Validation
- \`isNotNullOrUndefined\` always passed because the guard used \`&&\` instead of \`||\`.

### Subscriber follow events
- \`SUBSCRIBER_FOLLOW_DELETE\` / \`SUBSCRIBER_FOLLOW_UPDATE\` accessed \`this.client.followStore\` which doesn't exist; it's \`this.client.me.followStore\`. \`UPDATE\` also deleted the entry before patching.

### Import casing
- Several imports had wrong casing — fine on macOS/Windows but \`ERR_MODULE_NOT_FOUND\` on Linux.

### Deferred (TODO comments only)
- \`IconInfo.targetId\` is read in the placeholder fallback but never assigned; needs a 4th constructor arg threaded from \`Channel.js\` / \`User.js\`.
- \`ChannelMember\` \`#fetchList\` passes 4 args to a 2-arg constructor.
- \`validate(..., this, this.fetch)\` references a non-existent method in WOLF, Messaging, and UserFollow — error messages lose their \`Class.method()\` prefix.

## Skipped on rebase

The original branch contained these fixes but their target files don't exist on \`feat/3.0\`:
- GROUP_MEMBER_ADD: missing \`client\` arg to \`ChannelMember\` constructor
- GROUP_MEMBER_UPDATE: registered the wrong event name + called a non-existent method
- GROUP_MEMBER_DELETE: crashed when \`channel.fetch\` returned null
- GROUP_MEMBER_PRIVILEGED_DELETE: collided with \`GROUP_MEMBER_DELETE\` registration, missing \`memberStore\` guard

If member events are handled elsewhere on \`feat/3.0\`, these bug shapes may be worth re-checking there.

## Test plan
- [x] Live-verified kick / ban / silence / admin / mod / regular on a real channel (the original motivating bug)
- [x] Live-verified channel fetch by id and by name (single + array)
- [x] Live-verified tip details fallback
- [ ] Re-verify avatar and event thumbnail upload on this branch
- [ ] Re-verify subscriber follow events on this branch